### PR TITLE
Use dynamic version to create icon download links

### DIFF
--- a/src/__types__/index.ts
+++ b/src/__types__/index.ts
@@ -12,6 +12,7 @@ export type DetailedIcon = {
     description: string;
     author: string;
     size: number;
+    version: number;
 };
 export type IconType = {
     name: string;
@@ -21,6 +22,7 @@ export type IconType = {
     tags: string[];
     categories: string[];
     Icon?: any;
+    version: number;
 };
 export type MatIconList = {
     [key: string]: (props: SvgIconProps) => JSX.Element;

--- a/src/app/api/index.tsx
+++ b/src/app/api/index.tsx
@@ -111,10 +111,18 @@ export const getRoadmap = async (release: Release): Promise<RoadmapBucket[] | un
     }
 };
 
-export const getSvg = async (name: string, family: 'material' | 'brightlayer-ui'): Promise<string | undefined> => {
+type MUIIconDescription = { name: string; family: 'material'; version: number };
+type BLUIIconDescription = { name: string; family: 'brightlayer-ui'; version?: '' };
+export const getSvg = async ({
+    name,
+    family,
+    version = 1,
+}: MUIIconDescription | BLUIIconDescription): Promise<string | undefined> => {
     try {
         const response =
-            family === 'brightlayer-ui' ? await bluiIcons.get(`/${name}.svg`) : await icons.get(`/${name}/v6/24px.svg`);
+            family === 'brightlayer-ui'
+                ? await bluiIcons.get(`/${name}.svg`)
+                : await icons.get(`/${name}/v${version}/24px.svg`);
         if (response && response.status === 200) return response.data;
         return undefined;
     } catch (thrown) {

--- a/src/app/components/icons/IconBrowser.tsx
+++ b/src/app/components/icons/IconBrowser.tsx
@@ -84,6 +84,7 @@ const loadIcons = (): void => {
             description: '',
             author: '',
             size: 0,
+            version: 1,
         };
 
         // do not add obsolete icons to the search index or the master icon lists
@@ -113,6 +114,7 @@ const loadIcons = (): void => {
             categories: iconDetails.categories || [],
             // @ts-ignore
             Icon: MuiIcons[iconKey],
+            version: iconDetails.version,
         };
 
         // add the icon details to the allIcons map
@@ -140,6 +142,7 @@ const loadIcons = (): void => {
             description: '',
             author: '',
             size: 0,
+            version: 1,
         };
 
         // add the name and tags to the search index
@@ -156,6 +159,7 @@ const loadIcons = (): void => {
             categories: iconDetails.family || [],
             // @ts-ignore
             Icon: BLUIIcons[iconKey],
+            version: iconDetails.version ?? 1,
         };
 
         // add the icon details to the allIcons map

--- a/src/app/components/icons/index.tsx
+++ b/src/app/components/icons/index.tsx
@@ -7,7 +7,14 @@ export * from './IconDrawer';
 export * from './ProgressIconCard';
 export * from './UniversalIconBrowser';
 
-export const emptyIcon: IconType = { name: '', iconFontKey: '', isMaterial: true, tags: [], categories: [] };
+export const emptyIcon: IconType = {
+    name: '',
+    iconFontKey: '',
+    isMaterial: true,
+    tags: [],
+    categories: [],
+    version: 1,
+};
 export const emptyIconDetails: DetailedIcon = {
     name: '',
     filename: '',
@@ -18,4 +25,5 @@ export const emptyIconDetails: DetailedIcon = {
     description: '',
     author: '',
     size: 0,
+    version: 1,
 };

--- a/src/app/components/icons/utilityFunctions.tsx
+++ b/src/app/components/icons/utilityFunctions.tsx
@@ -78,7 +78,7 @@ export const createDownloadBluiPngElement = async (
     size: IconSize
 ): Promise<void> => {
     const formattedIconName = `${iconName}_${colorName}_${size}dp.png`;
-    const iconSrc = `https://github.com/etn-ccis/blui-icons/raw/dev/packages/png/png${size}/${formattedIconName}`;
+    const iconSrc = `https://raw.githubusercontent.com/etn-ccis/blui-icons/master/packages/png/png${size}/${formattedIconName}`;
     const icon = await fetch(iconSrc);
     const iconBlog = await icon.blob();
     const iconUrl = URL.createObjectURL(iconBlog);

--- a/src/app/components/icons/utilityFunctions.tsx
+++ b/src/app/components/icons/utilityFunctions.tsx
@@ -85,26 +85,32 @@ export const createDownloadBluiPngElement = async (
     createDownloadElement(iconUrl, formattedIconName);
 };
 
-export const createDownloadMaterialPngElement = (iconName: string, colorName: IconColor, size: IconSize): void => {
-    const iconUrl = `https://fonts.gstatic.com/s/i/materialicons/${iconName}/v6/${colorName}-${size}dp.zip`;
-    const formattedIconName = `${iconName}/v6/${colorName}-${size}dp.zip`;
+export const createDownloadMaterialPngElement = (
+    iconName: string,
+    colorName: IconColor,
+    size: IconSize,
+    version = 1
+): void => {
+    const iconUrl = `https://fonts.gstatic.com/s/i/materialicons/${iconName}/v${version}/${colorName}-${size}dp.zip`;
+    const formattedIconName = `${iconName}/v${version}/${colorName}-${size}dp.zip`;
     createDownloadElement(iconUrl, formattedIconName);
 };
 
 // Material or Brightlayer UI SVG icons
 export const downloadSvg = async (icon: IconType, color: IconColor, size: IconSize): Promise<void> => {
     if (icon.isMaterial) {
-        const iconData = (await getSvg(getSnakeCase(icon.name), 'material')) || '';
+        const iconData =
+            (await getSvg({ name: getSnakeCase(icon.name), family: 'material', version: icon.version })) || '';
         createDownloadSvgElement(icon, iconData, color, size);
     } else {
-        const iconData = (await getSvg(icon.iconFontKey, 'brightlayer-ui')) || '';
+        const iconData = (await getSvg({ name: icon.iconFontKey, family: 'brightlayer-ui' })) || '';
         createDownloadSvgElement(icon, iconData, color, size);
     }
 };
 // Material or Brightlayer UI PNG icons
 export const downloadPng = (icon: IconType, color: IconColor, size: IconSize): void => {
     if (icon.isMaterial) {
-        createDownloadMaterialPngElement(icon.iconFontKey, color, size);
+        createDownloadMaterialPngElement(icon.iconFontKey, color, size, icon.version);
     } else {
         const colorName = color === 'white' ? `${color}50` : `${color}500`;
         void createDownloadBluiPngElement(icon.iconFontKey, colorName, size);

--- a/src/app/shared/utilities.tsx
+++ b/src/app/shared/utilities.tsx
@@ -1,6 +1,16 @@
-export const getSnakeCase = (str: string): string => str.replace(/[A-Z]/g, '_$&').toLowerCase().slice(1);
+export const getSnakeCase = (str: string): string =>
+    str
+        .replace(/[A-Z]/g, '_$&')
+        .replace(/[0-9]+/g, '_$&')
+        .toLowerCase()
+        .slice(1);
 
-export const getKebabCase = (str: string): string => str.replace(/[A-Z]/g, '-$&').toLowerCase().slice(1);
+export const getKebabCase = (str: string): string =>
+    str
+        .replace(/[A-Z]/g, '-$&')
+        .replace(/[0-9]+/g, '-$&')
+        .toLowerCase()
+        .slice(1);
 
 export const snakeToKebabCase = (str: string): string => str.replaceAll('_', '-').toLowerCase();
 


### PR DESCRIPTION
<!-- If this pull request fixes an Issue, link it below. If not, you can remove the line below -->

Fixes #590.

<!-- Include a bulleted list summarizing the main changes you have made in this PR -->

#### Changes proposed in this Pull Request:

- Dynamically create download links using version from material metadata
- Fix issue with filename converter utilities when there are numbers in the name

<!-- Instruction for PR reviewers, if more complicated than a simple yarn start -->

#### To Test:

- Attempt to download the `Notifications` icon and the `Battery-0-Bar` icons
    - these are from two different versions of icons and previously could not both be downloaded successfully
