### PR TITLE
Add shoutout to our fellow design systems

### DIFF
--- a/src/__configuration__/landingPage/externalLinks.ts
+++ b/src/__configuration__/landingPage/externalLinks.ts
@@ -1,0 +1,34 @@
+type ExternalLink = {
+    title: string;
+    subtitle?: string;
+    link: string;
+    loginRequired?: boolean;
+};
+
+const externalLinks: ExternalLink[] = [
+    {
+        title: `Brightlayer Charts`,
+        subtitle: `A Design System for Data Visualization`,
+        link: `https://brightlayer-charts.azurewebsites.net/`,
+    },
+    {
+        title: `Design Thinking Resources`,
+        subtitle: `Methods, Best Practices, Trainings`,
+        link: `https://eaton.sharepoint.com/sites/ERG_DesignThinkingPractice`,
+        loginRequired: true,
+    },
+    {
+        title: `Communications & Brand Center`,
+        subtitle: `Eaton's Corporate Branding and Marketing`,
+        link: `https://eaton.sharepoint.com/sites/CommunicationsBrandCenter/SitePages/Branding-at-Eaton.aspx`,
+        loginRequired: true,
+    },
+    {
+        title: `Studio Blue`,
+        subtitle: `Human-Centered Design CoE`,
+        link: `https://eaton.sharepoint.com/sites/ERG_Human-CenteredDesign`,
+        loginRequired: true,
+    },
+];
+
+export default externalLinks;

--- a/src/app/components/navigation/SharedToolbar.tsx
+++ b/src/app/components/navigation/SharedToolbar.tsx
@@ -4,6 +4,7 @@ import {
     Typography,
     AppBar,
     Toolbar,
+    ListItem,
     ListItemText,
     AppBarProps,
     Hidden,
@@ -18,6 +19,8 @@ import {
     DialogTitle,
     TextField,
     MenuItem,
+    Menu,
+    Tooltip,
 } from '@mui/material';
 import { PxblueSmall } from '@brightlayer-ui/icons-mui';
 import { Spacer } from '@brightlayer-ui/react-components';
@@ -25,9 +28,12 @@ import { useLocation } from 'react-router-dom';
 import { useSelector, useDispatch } from 'react-redux';
 import { CHANGE_THEME, TOGGLE_DRAWER, TOGGLE_SEARCH } from '../../redux/actions';
 import { AppState } from '../../redux/reducers';
-import Search from '@mui/icons-material/Search';
+import SearchIcon from '@mui/icons-material/Search';
+import AppsIcon from '@mui/icons-material/Apps';
+import LockOpenIcon from '@mui/icons-material/LockOpen';
 import { SearchBar } from '../../pages';
 import { getScheduledSiteConfig } from '../../../__configuration__/themes';
+import externalLinks from '../../../__configuration__/landingPage/externalLinks';
 import FireworksCanvas from 'fireworks-canvas';
 
 export type SharedToolbarProps = AppBarProps & {
@@ -70,6 +76,8 @@ export const SharedToolbar = (props: SharedToolbarProps): JSX.Element => {
     const sidebarOpen = useSelector((state: AppState) => state.app.sidebarOpen);
     const showBanner = useSelector((state: AppState) => state.app.showBanner);
     const selectedTheme = useSelector((state: AppState) => state.app.theme);
+    const [externalLinkMenuAnchorEl, setExternalLinkMenuAnchorEl] = React.useState<null | HTMLElement>(null);
+    const isExternalLinkMenuOpen = Boolean(externalLinkMenuAnchorEl);
     const sm = useMediaQuery(theme.breakpoints.down('md'));
     const dispatch = useDispatch();
     const appBarBackground = getScheduledSiteConfig(selectedTheme).appBarBackground;
@@ -181,16 +189,59 @@ export const SharedToolbar = (props: SharedToolbarProps): JSX.Element => {
                     <IconButton
                         color={'inherit'}
                         size={'large'}
+                        onClick={(e): void => {
+                            setExternalLinkMenuAnchorEl(e.currentTarget);
+                        }}
+                    >
+                        <AppsIcon />
+                    </IconButton>
+                    <IconButton
+                        color={'inherit'}
+                        size={'large'}
                         edge={'end'}
                         onClick={(): void => {
                             dispatch({ type: TOGGLE_SEARCH, payload: true });
                         }}
                     >
-                        <Search />
+                        <SearchIcon />
                     </IconButton>
                 </Toolbar>
             </AppBar>
             <SearchBar />
+            {/* Convenient links to other design systems at Eaton*/}
+            <Menu
+                open={isExternalLinkMenuOpen}
+                anchorEl={externalLinkMenuAnchorEl}
+                onClose={(): void => {
+                    setExternalLinkMenuAnchorEl(null);
+                }}
+            >
+                {externalLinks.map((externalLink, index) => (
+                    <a
+                        href={externalLink.link}
+                        target={`_blank`}
+                        onClick={(): void => setExternalLinkMenuAnchorEl(null)}
+                        style={{ textDecoration: 'none', color: 'inherit' }}
+                        key={index}
+                    >
+                        <MenuItem>
+                            <ListItem
+                                dense
+                                secondaryAction={
+                                    externalLink.loginRequired ? (
+                                        <Tooltip title={`Requires login with Eaton credentials`}>
+                                            <LockOpenIcon fontSize={'small'} color={`disabled`} />
+                                        </Tooltip>
+                                    ) : undefined
+                                }
+                            >
+                                <ListItemText primary={externalLink.title} secondary={externalLink.subtitle} />
+                            </ListItem>
+                        </MenuItem>
+                    </a>
+                ))}
+            </Menu>
+            {/* Theme toggler */}
             <Dialog
                 open={showThemePicker}
                 onClose={(): void => {


### PR DESCRIPTION
I just feel like doing this.

## Changes proposed in this Pull Request:

- Added links to our external design system partners – BL Charts, Design Thinking, Corp Branding and Studio Blue

<!-- Include screenshots if they will help illustrate the changes in this PR -->

## Screenshots / Screen Recording (if applicable)

Top right corner of docit:

<img width="279" alt="image" src="https://user-images.githubusercontent.com/8997218/219215359-4c2b249c-a715-484b-9df2-81f4beb72ff1.png">

<img width="445" alt="image" src="https://user-images.githubusercontent.com/8997218/219215406-c63cbf1a-2232-4550-96b0-fdbfdf2b6213.png">

When you hover on those lock icons:

<img width="421" alt="image" src="https://user-images.githubusercontent.com/8997218/219215577-1d61f2ac-d228-4f58-a936-cc24e4182cd6.png">
