### PR TITLE
Added release notes for R27

### DIFF
--- a/src/docs/release-notes/R27/FullNotes.mdx
+++ b/src/docs/release-notes/R27/FullNotes.mdx
@@ -31,11 +31,11 @@ import React from 'react';
 
 #### React
 
--   PENDING MASTER PR @brightlayer-ui/react-components v6.3.0 ([Changelog](https://github.com/etn-ccis/blui-react-component-library/blob/master/CHANGELOG.md))
+-   @brightlayer-ui/react-components v6.3.0 ([Changelog](https://github.com/etn-ccis/blui-react-component-library/blob/master/CHANGELOG.md))
 
 #### React Native
 
--   PENDING MASTER PR @brightlayer-ui/react-native-components v7.1.0 ([Changelog](https://github.com/etn-ccis/blui-react-native-component-library/blob/master/CHANGELOG.md))
+-   @brightlayer-ui/react-native-components v7.1.0 ([Changelog](https://github.com/etn-ccis/blui-react-native-component-library/blob/master/CHANGELOG.md))
 
 #### Icons
 

--- a/src/docs/release-notes/R27/FullNotes.mdx
+++ b/src/docs/release-notes/R27/FullNotes.mdx
@@ -1,0 +1,45 @@
+import React from 'react';
+
+## Component Libraries
+
+-   Fixed 6 issues in Angular component library.
+-   Fixed 8 issues in React component library.
+-   Fixed 9 issues in React Native component library.
+
+## Documentation Site
+
+-   Added links to other design systems at Eaton on our main documentation site.
+-   Added new pages to the React developer documentation site to aggregate all developer instructions:
+    -   [Environment Setup](https://brightlayer-ui-components.github.io/react/getting-started/environment)
+    -   [Start a Brightlayer UI Project](https://brightlayer-ui-components.github.io/react/getting-started/start-a-project)
+    -   [A list of all components](https://brightlayer-ui-components.github.io/react/components/component-catalog)
+    -   [Themes overview, usage, and customization](https://brightlayer-ui-components.github.io/react/themes/overview)
+
+## Icons
+
+-   Added [33 new icons](https://github.com/etn-ccis/blui-icons/pull/269).
+
+## Misc
+
+-   Bug fixes & minor updates.
+
+## Package Summary
+
+#### Angular
+
+-   @brightlayer-ui/angular-components v8.1.0 ([Changelog](https://github.com/etn-ccis/blui-angular-component-library/blob/master/CHANGELOG.md))
+
+#### React
+
+-   PENDING MASTER PR @brightlayer-ui/react-components v6.3.0 ([Changelog](https://github.com/etn-ccis/blui-react-component-library/blob/master/CHANGELOG.md))
+
+#### React Native
+
+-   PENDING MASTER PR @brightlayer-ui/react-native-components v7.1.0 ([Changelog](https://github.com/etn-ccis/blui-react-native-component-library/blob/master/CHANGELOG.md))
+
+#### Icons
+
+-   @brightlayer-ui/icons v2.1.0 ([Changelog](https://github.com/etn-ccis/blui-icons/blob/master/packages/icon-font/CHANGELOG.md))
+-   @brightlayer-ui/icons-svg v1.12.0 ([Changelog](https://github.com/etn-ccis/blui-icons/blob/master/packages/svg/CHANGELOG.md))
+-   @brightlayer-ui/icons-mui v3.4.0 ([Changelog](https://github.com/etn-ccis/blui-icons/blob/master/packages/mui/CHANGELOG.md))
+-   @brightlayer-ui/react-native-vector-icons v2.1.0 ([Changelog](https://github.com/etn-ccis/blui-icons/blob/master/packages/rn-vector/CHANGELOG.md))

--- a/src/docs/release-notes/R27/Summary.mdx
+++ b/src/docs/release-notes/R27/Summary.mdx
@@ -1,1 +1,1 @@
-Added new contents to the [React developer documentation site](https://brightlayer-ui-components.github.io/react), and fixed multiple issues related to our component libraries.
+Added new contents to the [React developer documentation site](https://brightlayer-ui-components.github.io/react) and fixed multiple issues related to our component libraries.

--- a/src/docs/release-notes/R27/Summary.mdx
+++ b/src/docs/release-notes/R27/Summary.mdx
@@ -1,0 +1,1 @@
+Added new contents to the [React developer documentation site](https://brightlayer-ui-components.github.io/react), and fixed multiple issues related to our component libraries.

--- a/src/docs/release-notes/index.tsx
+++ b/src/docs/release-notes/index.tsx
@@ -1,6 +1,7 @@
 import React from 'react';
 
 // Full Release Notes
+import R27 from './R27/FullNotes.mdx';
 import R26 from './R26/FullNotes.mdx';
 import R25 from './R25/FullNotes.mdx';
 import R24 from './R24/FullNotes.mdx';
@@ -23,6 +24,7 @@ import R8 from './R8/FullNotes.mdx';
 import R7 from './R7/FullNotes.mdx';
 
 // Summaries (for Landing Page)
+import R27Summary from './R27/Summary.mdx';
 import R26Summary from './R26/Summary.mdx';
 import R25Summary from './R25/Summary.mdx';
 import R24Summary from './R24/Summary.mdx';
@@ -52,6 +54,13 @@ export type ReleaseInfo = {
     summary: JSX.Element;
 };
 const Releases: ReleaseInfo[] = [
+    {
+        title: 'R27',
+        date: 'Apr 2023',
+        version: '3.2.1',
+        details: <R27 />,
+        summary: <R27Summary />,
+    },
     {
         title: 'R26',
         date: 'Jan 2023',


### PR DESCRIPTION
<!-- If this pull request fixes an Issue, link it below. If not, you can remove the line below -->

Fixes BLUI-3923

<!-- Include a bulleted list summarizing the main changes you have made in this PR -->

## Changes proposed in this Pull Request:

- Added release notes for R27
<!-- Include screenshots if they will help illustrate the changes in this PR -->

## Any specific feedback you are looking for?

- Looking mostly for feedback on wording and whether I covered all "announceable" efforts. 
- Note that not everything works 100% in this PR due to several pending efforts:
  - Roadmap is still pointing to R27, because there is no R28 in the blui-database. I assume this will be updated after the PI planning
  - None of the React dev doc links work, because it has not been merged to master yet
  - angular and react component libraries are still waiting for their master PR to be actually published.
