### PR TITLE
Replaced execCommand with the Clipboard API

### DIFF
--- a/src/app/shared/utilities.tsx
+++ b/src/app/shared/utilities.tsx
@@ -43,8 +43,20 @@ function fallbackCopyTextToClipboard(text: string): void {
     textArea.focus();
     textArea.select();
 
-    document.execCommand('copy');
-    document.body.removeChild(textArea);
+    // document.execCommand('copy');
+
+    navigator.clipboard
+        .writeText(text)
+        .then(() => {
+            //console.log('Text copied to clipboard.');
+            // Perform additional actions here if needed
+        })
+        .catch((err) => {
+            console.error('Failed to copy text: ', err);
+        })
+        .finally(() => {
+            document.body.removeChild(textArea);
+        });
 }
 export function copyTextToClipboard(text: string, onCopied?: () => void): void {
     if (!navigator.clipboard) {

--- a/src/app/shared/utilities.tsx
+++ b/src/app/shared/utilities.tsx
@@ -43,13 +43,10 @@ function fallbackCopyTextToClipboard(text: string): void {
     textArea.focus();
     textArea.select();
 
-    // document.execCommand('copy');
-
     navigator.clipboard
         .writeText(text)
         .then(() => {
-            //console.log('Text copied to clipboard.');
-            // Perform additional actions here if needed
+            
         })
         .catch((err) => {
             console.error('Failed to copy text: ', err);

--- a/src/app/shared/utilities.tsx
+++ b/src/app/shared/utilities.tsx
@@ -45,9 +45,7 @@ function fallbackCopyTextToClipboard(text: string): void {
 
     navigator.clipboard
         .writeText(text)
-        .then(() => {
-            
-        })
+        .then(() => {})
         .catch((err) => {
             console.error('Failed to copy text: ', err);
         })


### PR DESCRIPTION
<!-- If this pull request fixes an Issue, link it below. If not, you can remove the line below -->

Fixes #482 

<!-- Include a bulleted list summarizing the main changes you have made in this PR -->

#### Changes proposed in this Pull Request:

- document.execCommand('copy') is deprecated so replaced it with Clipboard API to resolve

<!-- Include screenshots if they will help illustrate the changes in this PR -->

#### Screenshots / Screen Recording (if applicable)

-

<!-- Instruction for PR reviewers, if more complicated than a simple yarn start -->

#### To Test:

-

<!-- Useful for draft pull requests -->

#### Any specific feedback you are looking for?

-
