### PR TITLE
Move 'Introduction' pages to landing page

### DIFF
--- a/__scripts__/crawl/sitemap.json
+++ b/__scripts__/crawl/sitemap.json
@@ -40,8 +40,10 @@
                 {
                     "title": "Web Frameworks",
                     "url": "/frameworks-web",
+                    "hasLandingPage": true,
                     "pages": [
                         {
+                            "hidden": true,
                             "title": "Introduction",
                             "url": "/intro"
                         },
@@ -58,8 +60,10 @@
                 {
                     "title": "Mobile Frameworks",
                     "url": "/frameworks-mobile",
+                    "hasLandingPage": true,
                     "pages": [
                         {
+                            "hidden": true,
                             "title": "Introduction",
                             "url": "/intro"
                         },

--- a/src/__configuration__/navigationMenu/navigation.tsx
+++ b/src/__configuration__/navigationMenu/navigation.tsx
@@ -63,8 +63,10 @@ export const pageDefinitions: SimpleNavItem[] = [
             {
                 title: 'Web Frameworks',
                 url: 'frameworks-web',
+                component: <MarkdownPage title={'Web Framework Introduction'} markdown={Docs.Development.WebFrameworks.Intro}/>,
                 pages: [
                     {
+                        hidden: true,
                         title: 'Introduction',
                         url: 'intro',
                         component: (
@@ -93,8 +95,10 @@ export const pageDefinitions: SimpleNavItem[] = [
             {
                 title: 'Mobile Frameworks',
                 url: 'frameworks-mobile',
+                component: <MarkdownPage title={'Mobile Frameworks Introduction'} markdown={Docs.Development.MobileFrameworks.Intro} />,
                 pages: [
                     {
+                        hidden: true,
                         title: 'Introduction',
                         url: 'intro',
                         component: (

--- a/src/docs/development/frameworks-mobile/home.mdx
+++ b/src/docs/development/frameworks-mobile/home.mdx
@@ -1,0 +1,53 @@
+import React from 'react';
+import { Divider } from '../../../app/components';
+
+{/* KEYWORDS: mobile hybrid framework compare comparison */}
+
+# Brightlayer UI Mobile (Hybrid) Frameworks
+
+Brightlayer UI supports hybrid mobile application development using React Native. Some of the key considerations when using React Native are:
+
+-   Renders native UI elements (not a WebView)
+-   Can re-use application logic code (React)
+-   Requires writing new code for UI (learning curve)
+-   Does not use CSS for styling (learning curve)
+-   Provides access to hardware functionality through various plugins / libraries
+-   Has a large community of support
+-   Learn more on the [React Native Website](https://facebook.github.io/react-native/)
+
+<Divider style={{}} />
+
+# Building your application
+
+Follow our [React Native](/development/frameworks-mobile/react-native) guide for information on developing using this framework. This guide will walk you through the process of developing your application and ultimately creating a final binary to distribute (either to your testers or your final customers).
+
+## Deploying your application
+
+Once you have built your application into a distributable binary, there are two options for distributing it.
+
+### Visual Studio App Center (formerly HockeyApp)
+
+Visual Studio App Center gives you a way to test your app with users before you are ready for final distribution. This service allows you to upload app binaries and create lists of people with whom to share them. These people will be notified via email when new versions of the app are available, and they will be prompted to download and install them directly onto their devices. You will need to request access to Visual Studio App Center from IT.
+
+### App Store / Play Store
+
+For the final distribution of your application, you will need to utilize App Store Connect and / or Google Play Console.
+
+# What about other mobile frameworks?
+
+There is a wide variety of different technologies on the market for developing mobile apps, including native (Objective C / Swift, Kotlin / Java) and hybrid frameworks (Flutter, Ionic, Cordova, Xamarin, React Native, etc.).
+
+We recommend and support development using React Native for these key reasons:
+
+-   Maintaining a single code base that can deploy to iOS or Android saves time over building two separate native apps.
+-   React Native gives a truer native experience than other "web wrapper" frameworks, which tend to present a clunkier user experience.
+-   React Native has a well-supported open-source implementation of Material Design.
+-   Business logic code can be shared with existing web applications built using React.
+-   Supporting one framework allows us to concentrate our resources on building more features rather than having a smaller feature set across multiple technologies.
+-   Encouraging teams to use the same technology stack maximizes the potential for code sharing between different teams.
+
+There may be circumstances where a different technology makes more sense for your project. For example, if you have an existing web app built using Angular, you may not want to start from scratch and learn React in order to use React Native. In this case, you may be better off using a technology like Ionic to wrap your existing application in a wrapper for mobile.
+
+When selecting a technology for your project, you will need to weigh the pros and cons to determine which approach is best.
+
+<Divider style={{}} />

--- a/src/docs/development/frameworks-mobile/index.tsx
+++ b/src/docs/development/frameworks-mobile/index.tsx
@@ -1,6 +1,7 @@
 import Cordova from './cordova.mdx';
 import Intro from './intro.mdx';
+import Home from './home.mdx';
 import Ionic from './ionic.mdx';
 import ReactNative from './react-native.mdx';
 
-export { Cordova, Intro, Ionic, ReactNative };
+export { Cordova, Intro, Home, Ionic, ReactNative };

--- a/src/docs/development/frameworks-web/home.mdx
+++ b/src/docs/development/frameworks-web/home.mdx
@@ -1,0 +1,37 @@
+import React from 'react';
+import { Divider } from '../../../app/components';
+
+{/* KEYWORDS: introduction web framework compare comparison */}
+
+# Brightlayer UI Web Frameworks
+
+Brightlayer UI supports web application development using Angular and React. Both are open source JavaScript frameworks with large communities of support and both have open source component libraries implementing Material Design. The two are quite comparable and you would not go wrong by choosing either, but there are some notable differences outlined below.
+
+## Angular (with Angular Material)
+
+-   A comprehensive framework, with a lot of built-in features and functionality
+-   Written in TypeScript (superset of JavaScript with strong variable typing)
+-   Structured way of organizing your entire application (if following the Angular CLI)
+-   May be more accessible to developers with greater back-end or full-stack experience
+-   Maintained by Google
+-   Learn more on the [Angular website](https://angular.io/)
+
+## React (with MUI)
+
+-   A UI library for building custom Web Components / Applications
+-   Can be combined with additional libraries (e.g. Redux) to be a more comprehensive framework
+-   Virtual DOM allows for fewer re-renders (i.e., faster UI updates)
+-   May be more accessible to developers with greater experience with JavaScript and front-end development
+-   Maintained by Facebook
+-   Learn more on the [React website](https://reactjs.org/)
+
+<Divider style={{}} />
+
+# Which framework should I use?
+
+Choosing a framework is entirely up to you. They each have their own pros and cons, so you'll need to decide what is best for your application. In general, if you have developers who are very familiar with a particular framework, it might be worthwhile to use that framework to avoid any unnecessary learning curves associated with a new one. If you don't have development resources yet, you will probably want to conduct a more in-depth analysis of the available frameworks to decide what is most appropriate for your application. Feel free to reach out to us for assistance if needed.
+
+If you choose to use one of these frameworks, have a look at our Guides for using them with Brightlayer UI:
+
+-   [Angular Guide](/development/frameworks-web/angular)
+-   [React Guide](/development/frameworks-web/react)

--- a/src/docs/development/frameworks-web/index.tsx
+++ b/src/docs/development/frameworks-web/index.tsx
@@ -1,5 +1,6 @@
 import Intro from './intro.mdx';
+import Home from './home.mdx';
 import Angular from './angular.mdx';
 import React from './react.mdx';
 
-export { Intro, Angular, React };
+export { Intro, Home, Angular, React };


### PR DESCRIPTION
<!-- If this pull request fixes an Issue, link it below. If not, you can remove the line below -->

Fixes #683 .

<!-- Include a bulleted list summarizing the main changes you have made in this PR -->

#### Changes proposed in this Pull Request:

- Created new Home.mdx pages for Web Frameworks and Mobile Frameworks pages & copied content from their respective Introduction pages (Intro.mdx)
- Imported/exported new Home pages for these Web & Mobile Frameworks pages
- Hid the original Introduction pages in navigation & sitemap (until they can be removed)

<!-- Include screenshots if they will help illustrate the changes in this PR -->

#### Screenshots / Screen Recording (if applicable)

- 
![Mobile frameworks](https://github.com/etn-ccis/blui-doc-it/assets/60793674/5227a314-f14f-4ad6-a042-53783905c889)
![Web frameworks](https://github.com/etn-ccis/blui-doc-it/assets/60793674/82780a7c-f0b7-4bc7-a4e6-a20e35ef7d8f)


<!-- Instruction for PR reviewers, if more complicated than a simple yarn start -->

#### To Test:

- Click on Mobile/Web Frameworks pages, see that the drop-down is now also a link to a page

<!-- Useful for draft pull requests -->

#### Any specific feedback you are looking for?

-
