### PR TITLE
Add MD3 component stickersheet to design resources

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,1 +1,1 @@
-* @joebochill @huayunh @JeffGreiner-eaton @daileytj
+* @joebochill @huayunh @JeffGreiner-eaton @surajeaton

--- a/src/__configuration__/design/resources.tsx
+++ b/src/__configuration__/design/resources.tsx
@@ -25,7 +25,7 @@ export const patternLinks = [
 export const figmaCommunityFileLinks = [
     {
         title: 'Brightlayer UI Components + Tokens',
-        url: '    https://www.figma.com/community/file/1293308181354933598/brightlayer-ui-tokens-components-in-material-design-3',
+        url: 'https://www.figma.com/community/file/1293308181354933598/brightlayer-ui-tokens-components-in-material-design-3',
         description: 'Material and Brightlayer UI Figma tokens and components (Material Design 3 style)',
         image: componentStickersheet,
         background: { position: 'center' },

--- a/src/__configuration__/design/resources.tsx
+++ b/src/__configuration__/design/resources.tsx
@@ -24,9 +24,16 @@ export const patternLinks = [
 
 export const figmaCommunityFileLinks = [
     {
+        title: 'Brightlayer UI Components + Tokens',
+        url: '    https://www.figma.com/community/file/1293308181354933598/brightlayer-ui-tokens-components-in-material-design-3',
+        description: 'Material and Brightlayer UI Figma tokens and components (Material Design 3 style)',
+        image: componentStickersheet,
+        background: { position: 'center' },
+    },
+    {
         title: 'Brightlayer UI Component Sticker Sheet',
         url: 'https://www.figma.com/community/file/1024360297793425107',
-        description: 'Pre-built Material and Brightlayer UI Figma components',
+        description: 'Material and Brightlayer UI Figma components (Material Design 2 style)',
         image: componentStickersheet,
         background: { position: 'center' },
     },

--- a/src/__configuration__/design/resources.tsx
+++ b/src/__configuration__/design/resources.tsx
@@ -31,7 +31,7 @@ export const figmaCommunityFileLinks = [
         background: { position: 'center' },
     },
     {
-        title: 'Brightlayer UI Component Sticker Sheet',
+        title: 'Brightlayer UI Components',
         url: 'https://www.figma.com/community/file/1024360297793425107',
         description: 'Material and Brightlayer UI Figma components (Material Design 2 style)',
         image: componentStickersheet,


### PR DESCRIPTION
#### Changes proposed in this Pull Request:

- Added a link to the new Material Design 3 component sticker sheet
- Codeowner, replace Tom with Suraj

#### Screenshots / Screen Recording (if applicable)
<img width="781" alt="Screenshot 2023-10-09 at 4 40 44 PM" src="https://github.com/etn-ccis/blui-doc-it/assets/8997218/7e9edfe1-dd30-47af-b7a0-1e302736ebbd">


<!-- Instruction for PR reviewers, if more complicated than a simple yarn start -->

#### To Test:

- yarn start
- http://localhost:3000/resources/designer
