### PR TITLE
BLUI-4717: Use the latest icon package for the new icons

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,6 +1,6 @@
 version: 2.1
 orbs:
-    browser-tools: circleci/browser-tools@1.4.6
+    browser-tools: circleci/browser-tools@1.4.7
 jobs:
     build:
         docker:

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
     "dependencies": {
         "@brightlayer-ui/colors": "^3.1.1",
         "@brightlayer-ui/colors-branding": "^3.2.0",
-        "@brightlayer-ui/icons-mui": "^3.5.0",
+        "@brightlayer-ui/icons-mui": "^3.6.0",
         "@brightlayer-ui/react-components": "^6.3.0",
         "@brightlayer-ui/react-progress-icons": "^2.1.1",
         "@brightlayer-ui/react-themes": "^7.1.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1200,10 +1200,10 @@
   optionalDependencies:
     eslint-plugin-react "^7.28.0"
 
-"@brightlayer-ui/icons-mui@^3.5.0":
-  version "3.5.0"
-  resolved "https://registry.yarnpkg.com/@brightlayer-ui/icons-mui/-/icons-mui-3.5.0.tgz#f2eaab9328180aab28b8b6157bd8bdfb72783d60"
-  integrity sha512-mGN7f+d6Ia40JaQ0faqFMRi5sWWLOmquOEzR26n3jyz5Qhs4Ufs6Nnq6DZGlyABz2hDq2eSQf9cZlgauu4tBxQ==
+"@brightlayer-ui/icons-mui@^3.6.0":
+  version "3.6.0"
+  resolved "https://registry.yarnpkg.com/@brightlayer-ui/icons-mui/-/icons-mui-3.6.0.tgz#a15f145fad4360ae5aef00059c192bdb1376cd84"
+  integrity sha512-SW5+xMCAsF6kAQXkfj5EcD7K0DB8gwoqeEpnvIa4SC1dzToqIaxxSDZVFqWlFSi7s//h20DJWOIuujjeQJcqtQ==
 
 "@brightlayer-ui/prettier-config@^1.0.3":
   version "1.0.3"


### PR DESCRIPTION
<!-- If this pull request fixes an Issue, link it below. If not, you can remove the line below -->

Fixes BLUI-4717

Get the new icons published [here](https://github.com/etn-ccis/blui-icons/pull/307) to show on docit

## To Test

- Verify that all the new icons are showing properly on the icons page http://localhost:3000/style/icon-library
- I need help with the CI error on Chrome Driver