### PR TITLE
Move web & mobile intro pages to parent nav item

### DIFF
--- a/src/__configuration__/navigationMenu/navigation.tsx
+++ b/src/__configuration__/navigationMenu/navigation.tsx
@@ -63,17 +63,13 @@ export const pageDefinitions: SimpleNavItem[] = [
             {
                 title: 'Web Frameworks',
                 url: 'frameworks-web',
+                component: (
+                    <MarkdownPage
+                        title={'Web Framework Introduction'}
+                        markdown={Docs.Development.WebFrameworks.Intro}
+                    />
+                ),
                 pages: [
-                    {
-                        title: 'Introduction',
-                        url: 'intro',
-                        component: (
-                            <MarkdownPage
-                                title={'Web Framework Introduction'}
-                                markdown={Docs.Development.WebFrameworks.Intro}
-                            />
-                        ),
-                    },
                     {
                         title: 'Angular Guide',
                         url: 'angular',
@@ -93,17 +89,13 @@ export const pageDefinitions: SimpleNavItem[] = [
             {
                 title: 'Mobile Frameworks',
                 url: 'frameworks-mobile',
+                component: (
+                    <MarkdownPage
+                        title={'Mobile Framework Introduction'}
+                        markdown={Docs.Development.MobileFrameworks.Intro}
+                    />
+                ),
                 pages: [
-                    {
-                        title: 'Introduction',
-                        url: 'intro',
-                        component: (
-                            <MarkdownPage
-                                title={'Mobile Framework Introduction'}
-                                markdown={Docs.Development.MobileFrameworks.Intro}
-                            />
-                        ),
-                    },
                     {
                         hidden: true,
                         title: 'Apache Cordova Guide',


### PR DESCRIPTION
<!-- If this pull request fixes an Issue, link it below. If not, you can remove the line below -->

Fixes https://github.com/etn-ccis/blui-doc-it/issues/406

<!-- Include a bulleted list summarizing the main changes you have made in this PR -->

#### Changes proposed in this Pull Request:

- move web & mobile intro page to root parent nav
-
-

<!-- Include screenshots if they will help illustrate the changes in this PR -->

#### Screenshots / Screen Recording (if applicable)

- before
![image](https://github.com/user-attachments/assets/ed5d0537-646e-4e29-8df7-62811f330a0e)

- after
![image](https://github.com/user-attachments/assets/c794e074-b590-4949-aca1-159fedb318aa)


<!-- Instruction for PR reviewers, if more complicated than a simple yarn start -->

#### To Test:

-

<!-- Useful for draft pull requests -->

#### Any specific feedback you are looking for?

-
