### PR TITLE
updated url for react native theme and license info

### DIFF
--- a/src/__configuration__/contributors/currentMaintainers.ts
+++ b/src/__configuration__/contributors/currentMaintainers.ts
@@ -1,5 +1,3 @@
-import JeffeyGreiner from '../../app/assets/credits/jeffery-greiner.jpeg';
-import EktaGhag from '../../app/assets/credits/ekta-ghag.jpg';
 import SurajKarambe from '../../app/assets/credits/suraj-karambe.png';
 import ManojLokesh from '../../app/assets/credits/manoj-lokesh.jpg';
 import ArshdeepSingh from '../../app/assets/credits/arshdeep-singh.jpg';

--- a/src/docs/development/frameworks-mobile/react-native.mdx
+++ b/src/docs/development/frameworks-mobile/react-native.mdx
@@ -93,7 +93,7 @@ npm install --save @brightlayer-ui/react-native-themes
 yarn add @brightlayer-ui/react-native-themes
 ```
 
-> Using the Brightlayer UI React Native theme **requires** that you add the Open Sans font to your application. You can learn how to do this by reading the instructions for [Vanilla React Native](https://medium.com/react-native-training/react-native-custom-fonts-ccc9aacf9e5e). You can find the fonts [here](https://github.com/etn-ccis/blui-react-native/tree/master/packages/blui-react-native-cli-templates/blank-typescript/template/assets/fonts).
+> Using the Brightlayer UI React Native theme **requires** that you add the Open Sans font to your application. You can learn how to do this by reading the instructions for [Vanilla React Native](https://medium.com/react-native-training/react-native-custom-fonts-ccc9aacf9e5e). You can find the fonts [here](https://github.com/etn-ccis/blui-react-native/tree/master/packages/cli-templates/blank-typescript/template/assets/fonts).
 
 ## Applying the Theme
 
@@ -182,4 +182,4 @@ There are a lot of resources and components available on the market to help spee
 
 ## License Information
 
-[React Native](https://github.com/facebook/react-native/blob/main/LICENSE-docs) is available under the MIT License.
+[React Native](https://github.com/facebook/react-native/blob/main/LICENSE) is available under the MIT License.


### PR DESCRIPTION
<!-- If this pull request fixes an Issue, link it below. If not, you can remove the line below -->

Fixes https://github.com/etn-ccis/blui-doc-it/issues/807 .

<!-- Include a bulleted list summarizing the main changes you have made in this PR -->

#### Changes proposed in this Pull Request:

- Updated github urls for fonts and license info in React Native Guide page
-
-

<!-- Include screenshots if they will help illustrate the changes in this PR -->

#### Screenshots / Screen Recording (if applicable)

-
<img width="2382" height="1208" alt="image" src="https://github.com/user-attachments/assets/276f7def-a6d8-4940-9a6b-7b04e24a7917" />
<img width="2594" height="1582" alt="image" src="https://github.com/user-attachments/assets/3ae8f77d-f0d8-4be2-a32c-c062852765c9" />


<!-- Instruction for PR reviewers, if more complicated than a simple yarn start -->

#### To Test:

-

<!-- Useful for draft pull requests -->

#### Any specific feedback you are looking for?

-
